### PR TITLE
Update Icinga2Agent.psm1

### DIFF
--- a/Icinga2Agent/Icinga2Agent.psm1
+++ b/Icinga2Agent/Icinga2Agent.psm1
@@ -1,50 +1,119 @@
+<#
+.Synopsis
+   Icinga 2 PowerShell Module - the most flexible and easy way to configure and install Icinga 2 Agents on Windows. 
+.DESCRIPTION
+   More Information on https://github.com/Icinga/icinga2-powershell-module
+.EXAMPLE
+       $icinga = Icinga2AgentModule
+       $icinga = Icinga2AgentModule `
+              -AgentName        'windows-host-name' `
+              -Ticket           '3459843583450834508634856383459' `
+              -ParentZone       'icinga-master' `
+              -ParentEndpoints  'icinga2a', 'icinga2b' `
+              -CAServer         'icinga-master'
+
+    exit $icinga.install();
+ .NOTES
+    
+#>
 function Icinga2AgentModule {
+    
     #
     # Setup parameters which can be accessed
     # with -<ParamName>
     #
+    [CmdletBinding()]
     param(
-        # Agent setup
+       
+        # This is in general the name of your Windows host. It will have to match with your Icinga configuration, as it is part of the Icinga 2 Ticket and Certificate handling to ensure a valid certificate is generated
         [string]$AgentName,
+        # The Ticket you will receive from your Icinga 2 CA. In combination with the Icinga Director, it will tell you which Ticket you will require for your host
         [string]$Ticket,
+        # You can either leave this parameter or add it to allow the module to install or update the Icinga 2 Agent on your system
         [string]$InstallAgentVersion,
+        # Instead of setting the Agent Name with -AgentName, the PowerShell module is capable of retreiving the information automaticly from Windows. Please note this is not the FQDN
         [switch]$FetchAgentName             = $FALSE,
+        # Like -FetchAgentName, this argument will ensure the hostname is set inside the script, will however include the domain to provide the FQDN internally.
         [switch]$FetchAgentFQDN             = $FALSE,
+        # Allows to transform the hostname to either lower or upper case if required. 0: Do nothing 1: To lower case 2: To upper case
         [int]$TransformHostname             = 0,
 
-        # Agent configuration
+        # This variable allows to specify on which port the Icinga 2 Agent will listen on
         [int]$AgentListenPort               = 5665,
-        [string]$ParentZone,
+        # Each Icinga 2 Agent is in general forwarding it's check results to a parent master or satellite zone. Here you will have to specify the name of the parent zone
+        [string]$ParentZone,#
+        # Icinga 2 internals to make it configurable if the Agent is accepting configuration from the Icinga config master.
         [bool]$AcceptConfig                 = $TRUE,
+        # This argument will define if the Icinga 2 debug log will be enabled or disabled.
         [switch]$IcingaEnableDebugLog       = $FALSE,
+        # Allows to specify if the PowerShell Module will add a firewall rule, allowing Icinga 2 masters or Satellites to connect to the Icinga 2 Agent on the defined port
         [switch]$AgentAddFirewallRule       = $FALSE,
+        # This parameter requires an array of string values, to which endpoints the Agent should in general connect to. If you are only having one endpoint, only add one. You will have to specify all endpoints the Agent requires to connect to
         [array]$ParentEndpoints,
+        # While -ParentEndpoints will define the name of endpoints by an array, this parameter will allow to assign IP address and port configuration, allowing the Icinga 2 Agent to directly connect to parent Icinga 2 instances. To specify IP address and port, you will have to seperate these entries by using ';' without blank spaces. The order of the config has to match the assignment of -ParentEndpoints. You can specify the IP address only without a port definition by just leaving the last part. If you wish to not specify a config for a specific endpoint, simply add an empty string to the correct location.
         [array]$EndpointsConfig,
+        # Allows to specify global zones, which will be added into the icinga2.conf. Note: In case no global zone will be defined, director-global will be added by default. If you specify zones by yourself, please ensure to add director-global as this is not done automaticly when adding custom global-zones.
         [array]$GlobalZones                 = @( 'director-global' ),
+        
 
         # Agent installation / update
-        [string]$IcingaServiceUser,
-        [string]$DownloadUrl                = 'https://packages.icinga.com/windows/',
-        [string]$AgentInstallDirectory,
-        [switch]$AllowUpdates               = $FALSE,
-        [array]$InstallerHashes,
-        [switch]$FlushApiDirectory          = $FALSE,
+        <# This argument will allow to override the user the Icinga 2 service is running with. Windows provides some basic users already which can be configured:
 
-        # Agent signing
+        LocalSystem (Icinga default)
+        NT AUTHORITY\NetworkService
+        NT AUTHORITY\LocalService
+        If you require an own user, you can add that one as well for the argument. If a password is required for the user to login, seperate username and password with a ':'.
+
+        Example: jdoe:mysecretpassword
+
+        Furthermore you can also use domains in combination and pass them over.
+
+        Example: icinga\jdoe:mysecretpassword[string]$IcingaServiceUser,
+        #>
+        [string]$IcingaServiceUser,
+        #With this parameter you can define a download Url or local directory from which the module will download/install a specific Icinga 2 Agent MSI Installer package. Please ensure to only define the base download Url / Directory, as the Module will generate the MSI file name based on your operating system architecture and the version to install. The Icinga 2 MSI Installer name is internally build as follows: Icinga2-v[InstallAgentVersion]-[OSArchitecture].msi
+
+        # Full example: Icinga2-v2.8.0-x86_64.msi
+        [string]$DownloadUrl                = 'https://packages.icinga.com/windows/',
+        # Allows to specify in which directory the Icinga 2 Agent will be installed into. In case of an Agent update you can specify with this argument a new directory the new Agent will be installed into. The old directory will be removed caused by the required uninstaller process.
+        [string]$AgentInstallDirectory,
+        # In case the Icinga 2 Agent is already installed on the system, this parameter will allow you to configure if you wish to upgrade / downgrade to a specified version with the -InstallAgentVersion parameter as well. If none of both parameters is defined, the module will not update or downgrade the agent.
+        # If argument -AgentInstallDirectory is not specified, the Icinga 2 Agent will be installed into the same directory as before. In case defined, the PowerShell Module will use the new directory as installation target.
+        [switch]$AllowUpdates               = $FALSE,
+        # To ensure downloaded packages are build by the Icinga Team and not compromised by third parties, you will be able to provide an array of SHA1 hashes here. In case you have defined any hashses, the module will not continue with updating / installing the Agent in case the SHA1 hash of the downloaded MSI package is not matching one of the provided hashes of this parameter.
+        [array]$InstallerHashes,
+        # In case the Icinga Agent will accept configuration from the parent Icinga 2 system, it will possibly write data to /var/lib/icinga2/api/* By adding this parameter to your script call, all content inside the api directory will be flushed once a change is detected by the module which requires a restart of the Icinga 2 Agent
+        [switch]$FlushApiDirectory          = $FALSE,
+        
+        # Here you can provide a string to the Icinga 2 CA or any other CA responsible to generate the required certificates for the SSL communication between the Icinga 2 Agent and it's parent
         [string]$CAServer,
+        # TODO
         [string]$CACertificatePath,
+        # Here you can specify a custom port in case your CA Server is not listening on 5665 
         [int]$CAPort                        = 5665,
+        # The module will generate the certificates in general only if one of the required files is missing. By adding this parameter to your call, the module will force the re-creation of the certificates.
         [switch]$ForceCertificateGeneration = $FALSE,
+        # This option will allow the validation of the trusted-master.crt generated during certificate generation, to ensure we are connected to the correct endpoint to prevent possible man-in-the-middle attacks.
         [string]$CAFingerprint,
+        # Use this switch to enable the CAProxy feature Introduced with Icinga 2.8
         [switch]$CAProxy                    = $FALSE,
 
         # Director communication
+        #This argument will tell the PowerShell where the Icinga Director can be found. Please specify the entire path to the Icinga Director! Example: https://example.com/icingaweb2/director/
         [string]$DirectorUrl,
+        #To fetch the Ticket for a host, creating host objects or deploying the configuration you will have to authenticate against the Icinga Director. This parameter allows to set the User we shall use to login.
         [string]$DirectorUser,
+        # To fetch the Ticket for a host, creating host objects or deploying the configuration you will have to authenticate against the Icinga Director. This parameter allows to set the Password we shall use to login.
         [string]$DirectorPassword,
+        # TODO
         [string]$DirectorDomain,
+        # API key for specific host templates, allowing the configuration and creation of host objects within the Icinga Director without password authentication. This is the API token assigned to a host template. Hosts created with this token, will automaticly receive the Host-Template assigned to the API key. Furthermore this token allows to access the Icinga Director Self-Service API to fetch basic arguments for the module.
+        # Note: This argument requires Icinga Director API Version 1.4.0 or higher
         [string]$DirectorAuthToken,
+        # This argument allows you to parse either a valid JSON-String or an hashtable / array, containing all informations for the host object to create. Please note that using arrays or hashtable objects for this argument will require PowerShell version 3 and above.
         [System.Object]$DirectorHostObject,
+        # If you add this parameter to your script call, the PowerShell module will tell the Icinga Director to deploy outstanding configurations. This parameter can be used in combination with -DirectorHostObject, to create objects and deploy them right away. This argument requires the user and password argument and will not work with the Self Service api.
+        # Caution: If set, all outstanding deployments inside the Icinga Director will be deployed. Use with caution!!!
         [switch]$DirectorDeployConfig       = $FALSE,
 
         # NSClient Installer
@@ -56,18 +125,27 @@ function Icinga2AgentModule {
         [string]$NSClientInstallerPath,
 
         # Uninstaller arguments
+        # This argument is only used by the function 'uninstall' and will remove the remaining content from 'C:\Program Data\icinga2' to prepare a clean setup of the Icinga 2 infrastrucure.
         [switch]$FullUninstallation         = $FALSE,
+        # When this argument is set, the installed NSClient++ will be removed from the system as well. This argument is only used by calling the function 'uninstall'
         [switch]$RemoveNSClient             = $FALSE,
 
-        # Dump Config arguments
+        # Dump Icinga Config 
         [switch]$DumpIcingaConfig           = $FALSE,
+        # Dump Icinga Objects
         [switch]$DumpIcingaObjects          = $FALSE,
 
         #Internal handling
+        # This argument allows to shorten the entire call of the module, not requiring to define a custom variable and executing the installation function of the monitoring components.
         [switch]$RunInstaller               = $FALSE,
+        # This argument allows to shorten the entire call of the module, not requiring to define a custom variable and executing the uninstallation function of the monitoring components.
         [switch]$RunUninstaller             = $FALSE,
+        #In certain cases it could be required to ingore SSL certificate validations from the Icinga Web 2 installation (for example in case self-signed certificates are used). By default the PowerShell Module is validating SSL certificates and throws an error if the validation fails.
+        #In case self-signed certificates are used and not included to the local certificate store of the Windows machine, the module will fail. By providing this argument, validation will always be valid and the script will execute as if the certificate was valid.
         [switch]$IgnoreSSLErrors            = $FALSE,
+
         [switch]$DebugMode                  = $FALSE,
+        # Specify a path to either a directory or a file to write all output from the PowerShell module into a file for later debugging. In case a directory is specified, the script will automaticly create a new file with a unique name into it. If a file is specified which is not yet present, it will be created.
         [string]$ModuleLogFile
     );
 


### PR DESCRIPTION
Added cmdletbinding to Provide Help information via get-help. 

In future steps we should change some of the write-host to write-error, write-warning, write-verbose, write-debug etc. wich are also supported with cmdletbinding. 

**Output of get-help**



get-help -Full Icinga2AgentModule

NAME
    Icinga2AgentModule
    
ÜBERSICHT
    Icinga 2 PowerShell Module - the most flexible and easy way to configure and install Icinga 2 Agents on Windows.
    
    
SYNTAX
    Icinga2AgentModule [[-AgentName] <String>] [[-Ticket] <String>] [[-InstallAgentVersion] <String>] [-FetchAgentName] 
    [-FetchAgentFQDN] [[-TransformHostname] <Int32>] [[-AgentListenPort] <Int32>] [[-ParentZone] <String>] [[-AcceptConfig] 
    <Boolean>] [-IcingaEnableDebugLog] [-AgentAddFirewallRule] [[-ParentEndpoints] <Array>] [[-EndpointsConfig] <Array>] 
    [[-GlobalZones] <Array>] [[-IcingaServiceUser] <String>] [[-DownloadUrl] <String>] [[-AgentInstallDirectory] <String>] 
    [-AllowUpdates] [[-InstallerHashes] <Array>] [-FlushApiDirectory] [[-CAServer] <String>] [[-CACertificatePath] <String>] 
    [[-CAPort] <Int32>] [-ForceCertificateGeneration] [[-CAFingerprint] <String>] [-CAProxy] [[-DirectorUrl] <String>] 
    [[-DirectorUser] <String>] [[-DirectorPassword] <String>] [[-DirectorDomain] <String>] [[-DirectorAuthToken] <String>] 
    [[-DirectorHostObject] <Object>] [-DirectorDeployConfig] [-InstallNSClient] [-NSClientAddDefaults] [-NSClientEnableFirewall] 
    [-NSClientEnableService] [[-NSClientDirectory] <String>] [[-NSClientInstallerPath] <String>] [-FullUninstallation] 
    [-RemoveNSClient] [-DumpIcingaConfig] [-DumpIcingaObjects] [-RunInstaller] [-RunUninstaller] [-IgnoreSSLErrors] [-DebugMode] 
    [[-ModuleLogFile] <String>] [<CommonParameters>]
    
    
BESCHREIBUNG
    More Information on https://github.com/Icinga/icinga2-powershell-module
    

PARAMETER
    -AgentName <String>
        This is in general the name of your Windows host. It will have to match with your Icinga configuration, as it is part of the 
        Icinga 2 Ticket and Certificate handling to ensure a valid certificate is generated
        
        Erforderlich?                false
        Position?                    1
        Standardwert                 
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -Ticket <String>
        The Ticket you will receive from your Icinga 2 CA. In combination with the Icinga Director, it will tell you which Ticket 
        you will require for your host
        
        Erforderlich?                false
        Position?                    2
        Standardwert                 
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -InstallAgentVersion <String>
        You can either leave this parameter or add it to allow the module to install or update the Icinga 2 Agent on your system
        
        Erforderlich?                false
        Position?                    3
        Standardwert                 
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -FetchAgentName [<SwitchParameter>]
        Instead of setting the Agent Name with -AgentName, the PowerShell module is capable of retreiving the information 
        automaticly from Windows. Please note this is not the FQDN
        
        Erforderlich?                false
        Position?                    named
        Standardwert                 False
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -FetchAgentFQDN [<SwitchParameter>]
        Like -FetchAgentName, this argument will ensure the hostname is set inside the script, will however include the domain to 
        provide the FQDN internally.
        
        Erforderlich?                false
        Position?                    named
        Standardwert                 False
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -TransformHostname <Int32>
        Allows to transform the hostname to either lower or upper case if required. 0: Do nothing 1: To lower case 2: To upper case
        
        Erforderlich?                false
        Position?                    4
        Standardwert                 0
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -AgentListenPort <Int32>
        This variable allows to specify on which port the Icinga 2 Agent will listen on
        
        Erforderlich?                false
        Position?                    5
        Standardwert                 5665
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -ParentZone <String>
        Each Icinga 2 Agent is in general forwarding it's check results to a parent master or satellite zone. Here you will have to 
        specify the name of the parent zone
        
        Erforderlich?                false
        Position?                    6
        Standardwert                 
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -AcceptConfig <Boolean>
        Icinga 2 internals to make it configurable if the Agent is accepting configuration from the Icinga config master.
        
        Erforderlich?                false
        Position?                    7
        Standardwert                 True
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -IcingaEnableDebugLog [<SwitchParameter>]
        This argument will define if the Icinga 2 debug log will be enabled or disabled.
        
        Erforderlich?                false
        Position?                    named
        Standardwert                 False
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -AgentAddFirewallRule [<SwitchParameter>]
        Allows to specify if the PowerShell Module will add a firewall rule, allowing Icinga 2 masters or Satellites to connect to 
        the Icinga 2 Agent on the defined port
        
        Erforderlich?                false
        Position?                    named
        Standardwert                 False
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -ParentEndpoints <Array>
        This parameter requires an array of string values, to which endpoints the Agent should in general connect to. If you are 
        only having one endpoint, only add one. You will have to specify all endpoints the Agent requires to connect to
        
        Erforderlich?                false
        Position?                    8
        Standardwert                 
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -EndpointsConfig <Array>
        While -ParentEndpoints will define the name of endpoints by an array, this parameter will allow to assign IP address and 
        port configuration, allowing the Icinga 2 Agent to directly connect to parent Icinga 2 instances. To specify IP address and 
        port, you will have to seperate these entries by using ';' without blank spaces. The order of the config has to match the 
        assignment of -ParentEndpoints. You can specify the IP address only without a port definition by just leaving the last part. 
        If you wish to not specify a config for a specific endpoint, simply add an empty string to the correct location.
        
        Erforderlich?                false
        Position?                    9
        Standardwert                 
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -GlobalZones <Array>
        Allows to specify global zones, which will be added into the icinga2.conf. Note: In case no global zone will be defined, 
        director-global will be added by default. If you specify zones by yourself, please ensure to add director-global as this is 
        not done automaticly when adding custom global-zones.
        
        Erforderlich?                false
        Position?                    10
        Standardwert                 @( 'director-global' )
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -IcingaServiceUser <String>
        Agent installation / update
        This argument will allow to override the user the Icinga 2 service is running with. Windows provides some basic users 
        already which can be configured:
        
               LocalSystem (Icinga default)
               NT AUTHORITY\NetworkService
               NT AUTHORITY\LocalService
               If you require an own user, you can add that one as well for the argument. If a password is required for the user to 
        login, seperate username and password with a ':'.
        
               Example: jdoe:mysecretpassword
        
               Furthermore you can also use domains in combination and pass them over.
        
               Example: icinga\jdoe:mysecretpassword[string]$IcingaServiceUser,
        
        Erforderlich?                false
        Position?                    11
        Standardwert                 
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -DownloadUrl <String>
        Full example: Icinga2-v2.8.0-x86_64.msi
        
        Erforderlich?                false
        Position?                    12
        Standardwert                 https://packages.icinga.com/windows/
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -AgentInstallDirectory <String>
        Allows to specify in which directory the Icinga 2 Agent will be installed into. In case of an Agent update you can specify 
        with this argument a new directory the new Agent will be installed into. The old directory will be removed caused by the 
        required uninstaller process.
        
        Erforderlich?                false
        Position?                    13
        Standardwert                 
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -AllowUpdates [<SwitchParameter>]
        In case the Icinga 2 Agent is already installed on the system, this parameter will allow you to configure if you wish to 
        upgrade / downgrade to a specified version with the -InstallAgentVersion parameter as well. If none of both parameters is 
        defined, the module will not update or downgrade the agent.
        If argument -AgentInstallDirectory is not specified, the Icinga 2 Agent will be installed into the same directory as before. 
        In case defined, the PowerShell Module will use the new directory as installation target.
        
        Erforderlich?                false
        Position?                    named
        Standardwert                 False
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -InstallerHashes <Array>
        To ensure downloaded packages are build by the Icinga Team and not compromised by third parties, you will be able to provide 
        an array of SHA1 hashes here. In case you have defined any hashses, the module will not continue with updating / installing 
        the Agent in case the SHA1 hash of the downloaded MSI package is not matching one of the provided hashes of this parameter.
        
        Erforderlich?                false
        Position?                    14
        Standardwert                 
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -FlushApiDirectory [<SwitchParameter>]
        In case the Icinga Agent will accept configuration from the parent Icinga 2 system, it will possibly write data to 
        /var/lib/icinga2/api/* By adding this parameter to your script call, all content inside the api directory will be flushed 
        once a change is detected by the module which requires a restart of the Icinga 2 Agent
        
        Erforderlich?                false
        Position?                    named
        Standardwert                 False
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -CAServer <String>
        Here you can provide a string to the Icinga 2 CA or any other CA responsible to generate the required certificates for the 
        SSL communication between the Icinga 2 Agent and it's parent
        
        Erforderlich?                false
        Position?                    15
        Standardwert                 
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -CACertificatePath <String>
        TODO
        
        Erforderlich?                false
        Position?                    16
        Standardwert                 
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -CAPort <Int32>
        Here you can specify a custom port in case your CA Server is not listening on 5665
        
        Erforderlich?                false
        Position?                    17
        Standardwert                 5665
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -ForceCertificateGeneration [<SwitchParameter>]
        The module will generate the certificates in general only if one of the required files is missing. By adding this parameter 
        to your call, the module will force the re-creation of the certificates.
        
        Erforderlich?                false
        Position?                    named
        Standardwert                 False
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -CAFingerprint <String>
        This option will allow the validation of the trusted-master.crt generated during certificate generation, to ensure we are 
        connected to the correct endpoint to prevent possible man-in-the-middle attacks.
        
        Erforderlich?                false
        Position?                    18
        Standardwert                 
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -CAProxy [<SwitchParameter>]
        Use this switch to enable the CAProxy feature Introduced with Icinga 2.8
        
        Erforderlich?                false
        Position?                    named
        Standardwert                 False
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -DirectorUrl <String>
        Director communication
        This argument will tell the PowerShell where the Icinga Director can be found. Please specify the entire path to the Icinga 
        Director! Example: https://example.com/icingaweb2/director/
        
        Erforderlich?                false
        Position?                    19
        Standardwert                 
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -DirectorUser <String>
        To fetch the Ticket for a host, creating host objects or deploying the configuration you will have to authenticate against 
        the Icinga Director. This parameter allows to set the User we shall use to login.
        
        Erforderlich?                false
        Position?                    20
        Standardwert                 
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -DirectorPassword <String>
        To fetch the Ticket for a host, creating host objects or deploying the configuration you will have to authenticate against 
        the Icinga Director. This parameter allows to set the Password we shall use to login.
        
        Erforderlich?                false
        Position?                    21
        Standardwert                 
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -DirectorDomain <String>
        TODO
        
        Erforderlich?                false
        Position?                    22
        Standardwert                 
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -DirectorAuthToken <String>
        API key for specific host templates, allowing the configuration and creation of host objects within the Icinga Director 
        without password authentication. This is the API token assigned to a host template. Hosts created with this token, will 
        automaticly receive the Host-Template assigned to the API key. Furthermore this token allows to access the Icinga Director 
        Self-Service API to fetch basic arguments for the module.
        Note: This argument requires Icinga Director API Version 1.4.0 or higher
        
        Erforderlich?                false
        Position?                    23
        Standardwert                 
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -DirectorHostObject <Object>
        This argument allows you to parse either a valid JSON-String or an hashtable / array, containing all informations for the 
        host object to create. Please note that using arrays or hashtable objects for this argument will require PowerShell version 
        3 and above.
        
        Erforderlich?                false
        Position?                    24
        Standardwert                 
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -DirectorDeployConfig [<SwitchParameter>]
        If you add this parameter to your script call, the PowerShell module will tell the Icinga Director to deploy outstanding 
        configurations. This parameter can be used in combination with -DirectorHostObject, to create objects and deploy them right 
        away. This argument requires the user and password argument and will not work with the Self Service api.
        Caution: If set, all outstanding deployments inside the Icinga Director will be deployed. Use with caution!!!
        
        Erforderlich?                false
        Position?                    named
        Standardwert                 False
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -InstallNSClient [<SwitchParameter>]
        NSClient Installer
        
        Erforderlich?                false
        Position?                    named
        Standardwert                 False
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -NSClientAddDefaults [<SwitchParameter>]
        
        Erforderlich?                false
        Position?                    named
        Standardwert                 False
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -NSClientEnableFirewall [<SwitchParameter>]
        
        Erforderlich?                false
        Position?                    named
        Standardwert                 False
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -NSClientEnableService [<SwitchParameter>]
        
        Erforderlich?                false
        Position?                    named
        Standardwert                 False
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -NSClientDirectory <String>
        
        Erforderlich?                false
        Position?                    25
        Standardwert                 
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -NSClientInstallerPath <String>
        
        Erforderlich?                false
        Position?                    26
        Standardwert                 
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -FullUninstallation [<SwitchParameter>]
        Uninstaller arguments
        This argument is only used by the function 'uninstall' and will remove the remaining content from 'C:\Program Data\icinga2' 
        to prepare a clean setup of the Icinga 2 infrastrucure.
        
        Erforderlich?                false
        Position?                    named
        Standardwert                 False
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -RemoveNSClient [<SwitchParameter>]
        When this argument is set, the installed NSClient++ will be removed from the system as well. This argument is only used by 
        calling the function 'uninstall'
        
        Erforderlich?                false
        Position?                    named
        Standardwert                 False
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -DumpIcingaConfig [<SwitchParameter>]
        Dump Icinga Config
        
        Erforderlich?                false
        Position?                    named
        Standardwert                 False
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -DumpIcingaObjects [<SwitchParameter>]
        Dump Icinga Objects
        
        Erforderlich?                false
        Position?                    named
        Standardwert                 False
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -RunInstaller [<SwitchParameter>]
        Internal handling
         This argument allows to shorten the entire call of the module, not requiring to define a custom variable and executing the 
        installation function of the monitoring components.
        
        Erforderlich?                false
        Position?                    named
        Standardwert                 False
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -RunUninstaller [<SwitchParameter>]
        This argument allows to shorten the entire call of the module, not requiring to define a custom variable and executing the 
        uninstallation function of the monitoring components.
        
        Erforderlich?                false
        Position?                    named
        Standardwert                 False
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -IgnoreSSLErrors [<SwitchParameter>]
        In certain cases it could be required to ingore SSL certificate validations from the Icinga Web 2 installation (for example 
        in case self-signed certificates are used). By default the PowerShell Module is validating SSL certificates and throws an 
        error if the validation fails.
        In case self-signed certificates are used and not included to the local certificate store of the Windows machine, the module 
        will fail. By providing this argument, validation will always be valid and the script will execute as if the certificate was 
        valid.
        
        Erforderlich?                false
        Position?                    named
        Standardwert                 False
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -DebugMode [<SwitchParameter>]
        
        Erforderlich?                false
        Position?                    named
        Standardwert                 False
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    -ModuleLogFile <String>
        Specify a path to either a directory or a file to write all output from the PowerShell module into a file for later 
        debugging. In case a directory is specified, the script will automaticly create a new file with a unique name into it. If a 
        file is specified which is not yet present, it will be created.
        
        Erforderlich?                false
        Position?                    27
        Standardwert                 
        Pipelineeingaben akzeptieren?false
        Platzhalterzeichen akzeptieren?false
        
    <CommonParameters>
        Dieses Cmdlet unterstützt folgende allgemeine Parameter: "Verbose", "Debug",
        "ErrorAction", "ErrorVariable", "WarningAction", "WarningVariable",
        "OutBuffer", "PipelineVariable" und "OutVariable". Weitere Informationen finden Sie unter 
        "about_CommonParameters" (http://go.microsoft.com/fwlink/?LinkID=113216). 
    
EINGABEN
    
AUSGABEN
    
    -------------------------- BEISPIEL 1 --------------------------
    
    PS C:\>$icinga = Icinga2AgentModule
    
    $icinga = Icinga2AgentModule `
           -AgentName        'windows-host-name' `
           -Ticket           '3459843583450834508634856383459' `
           -ParentZone       'icinga-master' `
           -ParentEndpoints  'icinga2a', 'icinga2b' `
           -CAServer         'icinga-master'
    
    exit $icinga.install();
    
    